### PR TITLE
Add opm common to prereqs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,76 @@
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required (VERSION 2.8)
 
-set(MODULES_INSTALL_PREFIX  "share/opm" CACHE STRING "The modules will be installed in: \${CMAKE_INSTALL_PREFIX}/\${MODULES_INSTALL_PREFIX}/cmake/Modules")
+set( OPM_COMMON_ROOT "" CACHE PATH "Root directory containing OPM related cmake modules")
+option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 
-install(DIRECTORY cmake/Modules DESTINATION ${CMAKE_INSTALL_PREFIX}/${MODULES_INSTALL_PREFIX}/cmake)
-install(DIRECTORY cmake/Scripts DESTINATION ${CMAKE_INSTALL_PREFIX}/${MODULES_INSTALL_PREFIX}/cmake)
-install(DIRECTORY cmake/Templates DESTINATION ${CMAKE_INSTALL_PREFIX}/${MODULES_INSTALL_PREFIX}/cmake)
+if(NOT OPM_COMMON_ROOT)
+   find_package(opm-common QUIET)
+endif()
 
-list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
-include(OpmInit)
+if (opm-common_FOUND)
+   include(OpmInit)
+else()
+   if (NOT OPM_COMMON_ROOT AND SIBLING_SEARCH)
+      set(OPM_COMMON_ROOT ${PROJECT_SOURCE_DIR}/../opm-common)
+   endif()
+   if (OPM_COMMON_ROOT)
+      list( APPEND CMAKE_MODULE_PATH "${OPM_COMMON_ROOT}/cmake/Modules")
+      include (OpmInit OPTIONAL RESULT_VARIABLE OPM_INIT)
+      set( OPM_MACROS_ROOT ${OPM_COMMON_ROOT} )
+   endif()
 
-file (READ ${PROJECT_SOURCE_DIR}/dune.module DUNE_MODULE)
-OpmGetDuneModuleDirective ("Version" opm-common_VERSION "${DUNE_MODULE}")
+   if (NOT OPM_INIT)
+      message( "" )
+      message( " /-------------------------------------------------------------------------------\\")
+      message( " |  Could not locate the opm build macros. The opm build macros                  |")
+      message( " |  are in a separate repository - instructions to proceed:                      |")
+      message( " |                                                                               |")
+      message( " |    1. Clone the repository: git clone git@github.com:OPM/opm-common.git        |")
+      message( " |                                                                               |")
+      message( " |    2. Run cmake in the current project with -DOPM_COMMON_ROOT=<path>/opm-common |")
+      message( " |                                                                               |")
+      message( " \\-------------------------------------------------------------------------------/")
+      message( "" )
+      message( FATAL_ERROR "Could not find OPM Macros")
+   endif()
 
-configure_file(opm-common-config.cmake.in opm-common-config.cmake @ONLY)
-install(FILES ${PROJECT_BINARY_DIR}/opm-common-config.cmake
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/opm-common)
+endif()
+
+# not the same location as most of the other projects; this hook overrides
+macro (dir_hook)
+endmacro (dir_hook)
+
+# project information is in dune.module. Read this file and set variables.
+# we cannot generate dune.module since it is read by dunecontrol before
+# the build starts, so it makes sense to keep the data there then.
+include (OpmInit)
+
+# list of prerequisites for this particular project; this is in a
+# separate file (in cmake/Modules sub-directory) because it is shared
+# with the find module
+include (${project}-prereqs)
+
+# read the list of components from this file (in the project directory);
+# it should set various lists with the names of the files to include
+include (CMakeLists_files.cmake)
+
+macro (config_hook)
+endmacro (config_hook)
+
+macro (prereqs_hook)
+endmacro (prereqs_hook)
+
+macro (sources_hook)
+endmacro (sources_hook)
+
+macro (fortran_hook)
+endmacro (fortran_hook)
+
+macro (files_hook)
+endmacro (files_hook)
+
+macro (tests_hook)
+endmacro (tests_hook)
+
+# all setup common to the OPM library modules is done here
+include (OpmLibMain)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -1,0 +1,46 @@
+# This file sets up five lists:
+#	MAIN_SOURCE_FILES     List of compilation units which will be included in
+#	                      the library. If it isn't on this list, it won't be
+#	                      part of the library. Please try to keep it sorted to
+#	                      maintain sanity.
+#
+#	TEST_SOURCE_FILES     List of programs that will be run as unit tests.
+#
+#	TEST_DATA_FILES       Files from the source three that should be made
+#	                      available in the corresponding location in the build
+#	                      tree in order to run tests there.
+#
+#	EXAMPLE_SOURCE_FILES  Other programs that will be compiled as part of the
+#	                      build, but which is not part of the library nor is
+#	                      run as tests.
+#
+#	PUBLIC_HEADER_FILES   List of public header files that should be
+#	                      distributed together with the library. The source
+#	                      files can of course include other files than these;
+#	                      you should only add to this list if the *user* of
+#	                      the library needs it.
+
+# originally generated with the command:
+# find opm -name '*.c*' -printf '\t%p\n' | sort
+list (APPEND MAIN_SOURCE_FILES
+)
+
+# originally generated with the command:
+# find tests -name '*.cpp' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
+list (APPEND TEST_SOURCE_FILES
+	)
+
+# originally generated with the command:
+# find tests -name '*.xml' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
+list (APPEND TEST_DATA_FILES
+	)
+
+# originally generated with the command:
+# find tutorials examples -name '*.c*' -printf '\t%p\n' | sort
+list (APPEND EXAMPLE_SOURCE_FILES
+	)
+
+# programs listed here will not only be compiled, but also marked for
+# installation
+list (APPEND PROGRAM_SOURCE_FILES
+	)

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-all:
-	@echo "No-op"

--- a/cmake/Modules/Findopm-common.cmake
+++ b/cmake/Modules/Findopm-common.cmake
@@ -1,0 +1,39 @@
+# - Find the opm-common module
+#
+# Defines the following variables:
+#   opm-common_INCLUDE_DIRS    Directory of header files
+#   opm-common_LIBRARIES       Directory of shared object files
+#   opm-common_DEFINITIONS     Defines that must be set to compile
+#   opm-common_CONFIG_VARS     List of defines that should be in config.h
+#   HAVE_OPM_COMMON            Binary value to use in config.h
+
+# Copyright (C) 2013 Uni Research AS
+# This code is licensed under The GNU General Public License v3.0
+
+# use the generic find routine
+include (opm-common-prereqs)
+include (OpmPackage)
+find_opm_package (
+  # module name
+  "opm-common"
+
+  # dependencies
+  "${opm-common_DEPS}"
+
+  # header to search for
+  ""
+
+  # library to search for
+  ""
+
+  # defines to be added to compilations
+  ""
+
+  # test program
+  ""
+
+  # config variables
+  "${opm-common_CONFIG_VAR}"
+  )
+include (UseDynamicBoost)
+#debug_find_vars ("opm-common")

--- a/cmake/Modules/opm-autodiff-prereqs.cmake
+++ b/cmake/Modules/opm-autodiff-prereqs.cmake
@@ -18,7 +18,8 @@ set (opm-autodiff_DEPS
 	# DUNE prerequisites
 	"dune-common REQUIRED;
 	dune-istl REQUIRED;
-        dune-cornerpoint;
+  dune-cornerpoint;
+	opm-common REQUIRED;
 	opm-core REQUIRED"
 	# Eigen
 	"Eigen3 3.2.0"

--- a/cmake/Modules/opm-benchmarks-prereqs.cmake
+++ b/cmake/Modules/opm-benchmarks-prereqs.cmake
@@ -13,6 +13,7 @@ set (opm-benchmarks_DEPS
 	"Boost 1.44.0
 		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
 	# OPM dependency
-	"opm-core"
-	"opm-upscaling"
+	"opm-common REQUIRED"
+	"opm-core REQUIRED"
+	"opm-upscaling REQUIRED"
 	)

--- a/cmake/Modules/opm-common-prereqs.cmake
+++ b/cmake/Modules/opm-common-prereqs.cmake
@@ -1,0 +1,16 @@
+# -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t; compile-command: "cmake -Wdev" -*-
+# vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
+
+# defines that must be present in config.h for our headers
+set (opm-common_CONFIG_VAR
+	)
+
+# dependencies
+set (opm-common_DEPS
+	# compile with C99 support if available
+	"C99"
+	# compile with C++0x/11 support if available
+	"CXX11Features REQUIRED"
+	# various runtime library enhancements
+	""
+	)

--- a/cmake/Modules/opm-core-prereqs.cmake
+++ b/cmake/Modules/opm-core-prereqs.cmake
@@ -37,6 +37,7 @@ set (opm-core_DEPS
 	# DUNE dependency
 	"dune-common"
 	"dune-istl"
+	"opm-common REQUIRED"
 	# Parser library for ECL-type simulation models
 	"opm-parser REQUIRED"
 	# the code which implements the material laws

--- a/cmake/Modules/opm-material-prereqs.cmake
+++ b/cmake/Modules/opm-material-prereqs.cmake
@@ -16,6 +16,7 @@ set (opm-material_DEPS
 	# compile with C++0x/11 support if available
 	"CXX11Features REQUIRED"
 	# prerequisite OPM modules
+	"opm-common REQUIRED"
 	"opm-parser"
 	# DUNE dependency
 	"dune-common REQUIRED"

--- a/cmake/Modules/opm-polymer-prereqs.cmake
+++ b/cmake/Modules/opm-polymer-prereqs.cmake
@@ -17,8 +17,9 @@ set (opm-polymer_DEPS
 	# Ensembles-based Reservoir Tools
 	"ERT"
 	# OPM dependency
-	"opm-autodiff REQUIRED"
-	"opm-core REQUIRED"
+	"opm-autodiff REQUIRED;
+  opm-common REQUIRED;
+	opm-core REQUIRED"
 	# Eigen
 	"Eigen3 3.1 REQUIRED"
 	)

--- a/cmake/Modules/opm-porsol-prereqs.cmake
+++ b/cmake/Modules/opm-porsol-prereqs.cmake
@@ -18,6 +18,7 @@ set (opm-porsol_DEPS
 	"dune-common REQUIRED;
 	dune-istl REQUIRED;
 	dune-grid REQUIRED;
+  opm-common REQUIRED;
 	opm-core REQUIRED;
 	opm-material REQUIRED;
 	dune-cornerpoint REQUIRED"

--- a/cmake/Modules/opm-upscaling-prereqs.cmake
+++ b/cmake/Modules/opm-upscaling-prereqs.cmake
@@ -25,6 +25,7 @@ set (opm-upscaling_DEPS
 	dune-istl REQUIRED;
 	dune-geometry REQUIRED;
 	dune-grid REQUIRED;
+  opm-common REQUIRED;
 	opm-core REQUIRED;
 	dune-cornerpoint REQUIRED;
 	opm-porsol REQUIRED"

--- a/cmake/Modules/opm-verteq-prereqs.cmake
+++ b/cmake/Modules/opm-verteq-prereqs.cmake
@@ -15,5 +15,6 @@ set (opm-verteq_DEPS
 	"Boost 1.44.0
 		COMPONENTS date_time filesystem system iostreams unit_test_framework REQUIRED"
 	# OPM dependency
-	"opm-core"
+	"opm-common REQUIRED;
+	opm-core REQUIRED"
 	)

--- a/configure
+++ b/configure
@@ -17,6 +17,13 @@ for OPT in "$@"; do
     esac
 done
 
+# special work around the fact that dunecontrol does not specify
+# --with-$MODULE for the module it attempts to build
+ADDITIONAL_PARAMS=""
+if test -z "$mod_dir"; then
+    ADDITIONAL_PARAMS="--with-opm-common=\"$(pwd)\""
+fi
+
 # if it isn't specified, the look around in other known places
 conf_file=cmake/Scripts/configure
 if [ -z "$mod_dir" ]; then
@@ -32,4 +39,4 @@ if [ ! -r "$mod_dir/$conf_file" ]; then
 fi
 
 # forward to the corresponding script in the cmake/Scripts/ directory
-exec "$mod_dir/$conf_file" --src-dir="$src_dir" "$@"
+exec "$mod_dir/$conf_file" --src-dir="$src_dir" "$@" $ADDITIONAL_PARAMS

--- a/configure
+++ b/configure
@@ -1,5 +1,35 @@
 #!/bin/sh
+# this file is supposed to be located in the source directory
+src_dir=$(dirname $0)
 
-# for the opm-common module, the configuration is a no-op since it does
-# not provide any C/C++ source files
-exit 0
+# scan the arguments and set this if build macros could be specified
+mod_dir=
+for OPT in "$@"; do
+    case "$OPT" in
+        --with-opm-common=*)
+            # remove everything before equal sign and assign the rest
+            mod_dir=${OPT#*=}
+            # tilde expansion; note that doing eval may have side effects
+            mod_dir=$(eval echo $mod_dir)
+            # absolute path
+            [ -d "$mod_dir" ] && mod_dir=$(cd $mod_dir ; pwd)
+            ;;
+    esac
+done
+
+# if it isn't specified, the look around in other known places
+conf_file=cmake/Scripts/configure
+if [ -z "$mod_dir" ]; then
+    if [ -r "$src_dir/$conf_file" ]; then
+        mod_dir="$src_dir"
+    fi
+fi
+
+# terminate with error message here if the module directory is not found
+if [ ! -r "$mod_dir/$conf_file" ]; then
+    echo Build macros not located in \"$mod_dir\", use --with-opm-common= to specify! 1>&2
+    exit 1
+fi
+
+# forward to the corresponding script in the cmake/Scripts/ directory
+exec "$mod_dir/$conf_file" --src-dir="$src_dir" "$@"

--- a/dune.module
+++ b/dune.module
@@ -1,4 +1,4 @@
 Module: opm-common
-Description: Open Porous Media Initiative common module
+Description: Open Porous Media Initiative shared infrastructure
 Version: 2015.10
 Maintainer: opm@opm-project.org


### PR DESCRIPTION
this restores dunecontrol compatibility and prepares the module for the addition of c++ code.
