### PR TITLE
Add option to ignore extra keywords in the regresstion testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,12 +36,10 @@ set(OPM_PROJECT_EXTRA_CODE_INTREE "#ENABLE_ECL_INPUT is needed by opm-common-pre
                                    include(OpmPackage) #Make macros availabe after find_package(opm-common)")
 if(ENABLE_ECL_OUTPUT)
   set(OPM_PROJECT_EXTRA_CODE_INSTALLED "${OPM_PROJECT_EXTRA_CODE_INSTALLED}
-                                        set(COMPARE_SUMMARY_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/compareSummary)
                                         set(COMPARE_ECL_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/compareECL)
                                         set(OPM_PACK_COMMAND ${CMAKE_INSTALL_PREFIX}/bin${${name}_VER_DIR}/opmpack)")
 
   set(OPM_PROJECT_EXTRA_CODE_INTREE "${OPM_PROJECT_EXTRA_CODE_INTREE}
-                                     set(COMPARE_SUMMARY_COMMAND ${PROJECT_BINARY_DIR}/bin/compareSummary)
                                      set(COMPARE_ECL_COMMAND ${PROJECT_BINARY_DIR}/bin/compareECL)
                                      set(OPM_PACK_COMMAND ${PROJECT_BINARY_DIR}/bin/opmpack)")
 endif()
@@ -142,10 +140,8 @@ if(ENABLE_ECL_INPUT)
               examples/test_util/summaryIntegrationTest.cpp
               examples/test_util/summaryRegressionTest.cpp)
   target_link_libraries(testutil ecl)
-  foreach(app compareECL compareSummary)
-    add_executable(${app} examples/test_util/${app}.cpp)
-    target_link_libraries(${app} testutil opmcommon)
-  endforeach()
+  add_executable(compareECL examples/test_util/compareECL.cpp)
+  target_link_libraries(compareECL testutil opmcommon)
 
   # Add the tests
   set(_libs testutil opmcommon
@@ -160,7 +156,7 @@ if(ENABLE_ECL_INPUT)
     set_target_properties(test_EclFilesComparator PROPERTIES
                           COMPILE_DEFINITIONS BOOST_TEST_DYN_LINK)
   endif()
-  install(TARGETS compareECL compareSummary DESTINATION bin)
+  install(TARGETS compareECL DESTINATION bin)
 endif()
 
 # Install build system files

--- a/examples/test_util/EclRegressionTest.cpp
+++ b/examples/test_util/EclRegressionTest.cpp
@@ -231,20 +231,23 @@ void ECLRegressionTest::gridCompare(const bool volumecheck) const {
 
 
 void ECLRegressionTest::results() {
-    if (keywords1.size() != keywords2.size()) {
-        std::set<std::string> keys(keywords1.begin() , keywords1.end());
-        for (const auto& key2: keywords2)
-            keys.insert( key2 );
+    if (!this->acceptExtraKeywords) {
+        if (keywords1.size() != keywords2.size()) {
+            std::set<std::string> keys(keywords1.begin() , keywords1.end());
+            for (const auto& key2: keywords2)
+                keys.insert( key2 );
 
-        for (const auto& key : keys)
-            fprintf(stderr," %8s:%3d     %8s:%3d \n",key.c_str() , ecl_file_get_num_named_kw( ecl_file1 , key.c_str()),
-                                                     key.c_str() , ecl_file_get_num_named_kw( ecl_file2 , key.c_str()));
+            for (const auto& key : keys)
+                fprintf(stderr," %8s:%3d     %8s:%3d \n",key.c_str() , ecl_file_get_num_named_kw( ecl_file1 , key.c_str()),
+                                                         key.c_str() , ecl_file_get_num_named_kw( ecl_file2 , key.c_str()));
 
 
-        OPM_THROW(std::runtime_error, "\nKeywords in first file: " << keywords1.size()
-                << "\nKeywords in second file: " << keywords2.size()
-                << "\nThe number of keywords differ.");
+            OPM_THROW(std::runtime_error, "\nKeywords in first file: " << keywords1.size()
+                      << "\nKeywords in second file: " << keywords2.size()
+                      << "\nThe number of keywords differ.");
+        }
     }
+
     for (const auto& it : keywords1)
         resultsForKeyword(it);
 

--- a/examples/test_util/EclRegressionTest.hpp
+++ b/examples/test_util/EclRegressionTest.hpp
@@ -40,6 +40,9 @@ class ECLRegressionTest: public ECLFilesComparator {
         // Only compare last occurrence
         bool onlyLastOccurrence = false;
 
+        bool acceptExtraKeywords = false;
+
+
         // Prints results stored in absDeviation and relDeviation.
         void printResultsForKeyword(const std::string& keyword) const;
 
@@ -68,6 +71,11 @@ class ECLRegressionTest: public ECLFilesComparator {
 
         //! \brief Option to only compare last occurrence
         void setOnlyLastOccurrence(bool onlyLastOccurrenceArg) {this->onlyLastOccurrence = onlyLastOccurrenceArg;}
+
+        // Accept extra keywords: If this switch is set to true the comparison
+        // of restart files will ignore extra keywords which area only present
+        // in the new simulation.
+        void setAcceptExtraKeywords(bool acceptExtraKeywords) { this->acceptExtraKeywords = acceptExtraKeywords; }
 
         //! \brief Compares grid properties of the two cases.
         // gridCompare() checks if both the number of active and global cells in the two cases are the same. If they are, and volumecheck is true, all cells are looped over to calculate the cell volume deviation for the two cases. If the both the relative and absolute deviation exceeds the tolerances, an exception is thrown.

--- a/examples/test_util/compareECL.cpp
+++ b/examples/test_util/compareECL.cpp
@@ -18,6 +18,9 @@
 
 #include "EclIntegrationTest.hpp"
 #include "EclRegressionTest.hpp"
+#include "summaryIntegrationTest.hpp"
+#include "summaryRegressionTest.hpp"
+
 #include <opm/common/ErrorMacros.hpp>
 
 #include <ert/util/util.h>
@@ -30,7 +33,7 @@
 #include <getopt.h>
 
 static void printHelp() {
-    std::cout << "\ncompareECL compares ECLIPSE files (restart (.RST), unified restart (.UNRST), initial (.INIT) or .RFT) and gridsizes (from .EGRID or .GRID file) from two simulations.\n"
+    std::cout << "\ncompareECL compares ECLIPSE files (restart (.RST), unified restart (.UNRST), initial (.INIT), summary (.SMRY), unified summary (.UNSMRY) or .RFT) and gridsizes (from .EGRID or .GRID file) from two simulations.\n"
         << "The program takes four arguments:\n\n"
         << "1. Case number 1 (full path without extension)\n"
         << "2. Case number 2 (full path without extension)\n"
@@ -38,25 +41,32 @@ static void printHelp() {
         << "4. Relative tolerance (between 0 and 1)\n\n"
         << "In addition, the program takes these options (which must be given before the arguments):\n\n"
         << "-a Run a full analysis of errors.\n"
+        << "-g Will print the vector with the greatest error ratio.\n"
         << "-h Print help and exit.\n"
         << "-i Execute integration test (regression test is default).\n"
         << "   The integration test compares SGAS, SWAT and PRESSURE in unified restart files, so this option can not be used in combination with -t.\n"
         << "-I Same as -i, but throws an exception when the number of keywords in the two cases differ. Can not be used in combination with -t.\n"
         << "-k Specify specific keyword to compare (capitalized), for example -k PRESSURE.\n"
+        << "-K Will not allow different amount of keywords in the two files. Throws an exception if the amount are different.\n"
         << "-l Only do comparison for the last occurrence. This option is only for the regression test, and can therefore not be used in combination with -i or -I.\n"
+        << "-m mainVar. Will calculate the error ratio for one main variable. Valid input is WOPR, WWPR, WGPR or WBHP.\n"
         << "-n Do not throw on errors.\n"
         << "-p Print keywords in both cases and exit. Can not be used in combination with -P.\n"
         << "-P Print common and uncommon keywords in both cases and exit. Can not be used in combination with -p.\n"
+        << "-R Will allow comparison between a restarted simulation and a normal simulation for summary regression tests. The files must end at the same time.\n"
+        << "-s int Sets the number of spikes that are allowed for each keyword in summary integration tests.\n"
         << "-t Specify ECLIPSE filetype to compare (unified restart is default). Can not be used in combination with -i or -I. Different possible arguments are:\n"
         << "    -t UNRST \t Compare two unified restart files (.UNRST). This the default value, so it is the same as not passing option -t.\n"
         << "    -t INIT  \t Compare two initial files (.INIT).\n"
         << "    -t RFT   \t Compare two RFT files (.RFT).\n"
         << "    -t RST   \t Compare two cases consisting of restart files (.Xnnnn).\n"
+        << "    -t SMRY  \t Compare two cases consistent of (unified) summary files.\n"
         << "    -t RST1  \t Compare two cases where the first case consists of restart files (.Xnnnn), and the second case consists of a unified restart file (.UNRST).\n"
         << "    -t RST2  \t Compare two cases where the first case consists of a unified restart file (.UNRST), and the second case consists of restart files (.Xnnnn).\n"
         << "   Note that when dealing with restart files (.Xnnnn), the program concatenates all of them into one unified restart file, which is used for comparison and stored in the same directory as the restart files.\n"
         << "   This will overwrite any existing unified restart file in that directory.\n\n"
-        << "Example usage of the program: \n\n"
+        << "-v For the rate keywords WOPR, WGPR, WWPR and WBHP. Calculates the error volume of the two summary files. This is printed to screen.\n"
+        << "\nExample usage of the program: \n\n"
         << "compareECL -k PRESSURE <path to first casefile> <path to second casefile> 1e-3 1e-5\n"
         << "compareECL -t INIT -k PORO <path to first casefile> <path to second casefile> 1e-3 1e-5\n"
         << "compareECL -i <path to first casefile> <path to second casefile> 0.01 1e-6\n\n"
@@ -109,24 +119,36 @@ int main(int argc, char** argv) {
     ecl_file_enum file_type      = ECL_UNIFIED_RESTART_FILE;
     // RegressionTest is default
     bool integrationTest         = false;
+    bool allowDifferentAmount    = true;
     bool checkNumKeywords        = false;
+    bool findGreatestErrorRatio  = false;
+    bool findVolumeError         = false;
     bool onlyLastOccurrence      = false;
     bool printKeywords           = false;
     bool printKeywordsDifference = false;
+    bool restartFile             = false;
     bool specificKeyword         = false;
     bool specificFileType        = false;
+    bool allowSpikes             = false;
     bool throwOnError            = true;
+    bool throwTooGreatErrorRatio = true;
     bool analysis                = false;
     bool volumecheck             = true;
     char* keyword                = nullptr;
     char* fileTypeCstr           = nullptr;
+    const char* mainVariable     = nullptr;
     int c                        = 0;
+    int spikeLimit               = -1;
 
-    while ((c = getopt(argc, argv, "hiIk:alnpPt:V")) != -1) {
+    while ((c = getopt(argc, argv, "hiIk:alnpPt:VRgs:m:v")) != -1) {
         switch (c) {
             case 'a':
               analysis = true;
               break;
+            case 'g':
+                findGreatestErrorRatio = true;
+                throwTooGreatErrorRatio = false;
+                break;
             case 'h':
                 printHelp();
                 return 0;
@@ -137,15 +159,21 @@ int main(int argc, char** argv) {
                 integrationTest = true;
                 checkNumKeywords = true;
                 break;
-            case 'n':
-                throwOnError = false;
-                break;
             case 'k':
                 specificKeyword = true;
                 keyword = optarg;
                 break;
+            case 'K':
+                allowDifferentAmount = false;
+                break;
             case 'l':
                 onlyLastOccurrence = true;
+                break;
+            case 'm':
+                mainVariable = optarg;
+                break;
+            case 'n':
+                throwOnError = false;
                 break;
             case 'p':
                 printKeywords = true;
@@ -153,16 +181,26 @@ int main(int argc, char** argv) {
             case 'P':
                 printKeywordsDifference = true;
                 break;
+            case 'R':
+                restartFile = true;
+                break;
+            case 's':
+                allowSpikes = true;
+                spikeLimit = atof(optarg);
+                break;
             case 't':
                 specificFileType = true;
                 fileTypeCstr = optarg;
+                break;
+            case 'v':
+                findVolumeError = true;
                 break;
             case 'V':
                 volumecheck = false;
                 break;
             case '?':
-                if (optopt == 'k') {
-                    std::cerr << "Option k requires a keyword as argument, see manual (-h) for more information." << std::endl;
+                if (optopt == 'k' || optopt == 'm' || optopt == 's') {
+                    std::cerr << "Option " << optopt << " requires a keyword as argument, see manual (-h) for more information." << std::endl;
                     return EXIT_FAILURE;
                 }
                 else if (optopt == 't') {
@@ -191,6 +229,7 @@ int main(int argc, char** argv) {
             << "Please run compareECL -h to see manual." << std::endl;
         return EXIT_FAILURE;
     }
+
     std::string basename1 = argv[argOffset];
     std::string basename2 = argv[argOffset + 1];
     double absTolerance   = strtod(argv[argOffset + 2], nullptr);
@@ -216,14 +255,66 @@ int main(int argc, char** argv) {
         else if (fileTypeString == "RFT") {
             file_type = ECL_RFT_FILE;
         }
+        else if (fileTypeString == "SMRY")
+            file_type = ECL_SUMMARY_FILE;
         else {
             std::cerr << "Unknown ECLIPSE filetype specified with option -t. Please run compareECL -h to see manual." << std::endl;
             return EXIT_FAILURE;
         }
     }
+
+    if (restartFile && (file_type != ECL_SUMMARY_FILE || integrationTest)) {
+        std::cerr << "Error: -R can only be used in for summary regression tests." << std::endl;
+        return EXIT_FAILURE;
+    }
+
     std::cout << "Comparing '" << basename1 << "' to '" << basename2 << "'." << std::endl;
     try {
-        if (integrationTest) {
+        if (file_type == ECL_SUMMARY_FILE) {
+            if(!integrationTest){
+                SummaryRegressionTest compare(basename1,basename2,absTolerance,relTolerance);
+                compare.throwOnErrors(throwOnError);
+                compare.doAnalysis(analysis);
+                compare.setPrintKeywords(printKeywords);
+                compare.setIsRestartFile(restartFile);
+                if(specificKeyword){
+                    compare.getRegressionTest(keyword);
+                }
+                else{
+                    compare.setPrintKeywords(printKeywords);
+                    compare.getRegressionTest();
+                }
+            } else {
+                SummaryIntegrationTest compare(basename1,basename2,absTolerance,relTolerance);
+                compare.throwOnErrors(throwOnError);
+                compare.setFindVectorWithGreatestErrorRatio(findGreatestErrorRatio);
+                compare.setAllowSpikes(allowSpikes);
+                if (mainVariable) {
+                    compare.setOneOfTheMainVariables(true);
+                    std::string str(mainVariable);
+                    std::transform(str.begin(), str.end(),str.begin(), ::toupper);
+                    if(str == "WOPR" ||str=="WWPR" ||str=="WGPR" || str == "WBHP"){
+                        compare.setMainVariable(str);
+                    }else{
+                        throw std::invalid_argument("The input is not a main variable. -m option requires a valid main variable.");
+                    }
+                }
+                compare.setFindVolumeError(findVolumeError);
+                if (spikeLimit != -1) {
+                    compare.setSpikeLimit(spikeLimit);
+                }
+                compare.setAllowDifferentAmountOfKeywords(allowDifferentAmount);
+                compare.setPrintKeywords(printKeywords);
+                compare.setThrowExceptionForTooGreatErrorRatio(throwTooGreatErrorRatio);
+                if(specificKeyword){
+                    compare.setPrintSpecificKeyword(specificKeyword);
+                    compare.getIntegrationTest(keyword);
+                    return 0;
+                }
+                compare.getIntegrationTest();
+            }
+        }
+        else if (integrationTest) {
             ECLIntegrationTest comparator(basename1, basename2, absTolerance, relTolerance);
             if (printKeywords) {
                 comparator.printKeywords();

--- a/examples/test_util/compareECL.cpp
+++ b/examples/test_util/compareECL.cpp
@@ -132,6 +132,7 @@ int main(int argc, char** argv) {
     bool allowSpikes             = false;
     bool throwOnError            = true;
     bool throwTooGreatErrorRatio = true;
+    bool acceptExtraKeywords     = false;
     bool analysis                = false;
     bool volumecheck             = true;
     char* keyword                = nullptr;
@@ -140,7 +141,7 @@ int main(int argc, char** argv) {
     int c                        = 0;
     int spikeLimit               = -1;
 
-    while ((c = getopt(argc, argv, "hiIk:alnpPt:VRgs:m:v")) != -1) {
+    while ((c = getopt(argc, argv, "hiIk:alnpPt:VRgs:m:vx")) != -1) {
         switch (c) {
             case 'a':
               analysis = true;
@@ -197,6 +198,9 @@ int main(int argc, char** argv) {
                 break;
             case 'V':
                 volumecheck = false;
+                break;
+            case 'x':
+                acceptExtraKeywords = true;
                 break;
             case '?':
                 if (optopt == 'k' || optopt == 'm' || optopt == 's') {
@@ -344,6 +348,7 @@ int main(int argc, char** argv) {
             ECLRegressionTest comparator(file_type, basename1, basename2, absTolerance, relTolerance);
             comparator.throwOnErrors(throwOnError);
             comparator.doAnalysis(analysis);
+            comparator.setAcceptExtraKeywords(acceptExtraKeywords);
             if (printKeywords) {
                 comparator.printKeywords();
                 return 0;

--- a/examples/test_util/summaryRegressionTest.cpp
+++ b/examples/test_util/summaryRegressionTest.cpp
@@ -98,7 +98,7 @@ void SummaryRegressionTest::getRegressionTest(){
     }
     if (throwAtEnd)
       OPM_THROW(std::runtime_error, "Regression test failed.");
-    else
+    else if (deviations.empty())
       std::cout << "Regression test succeeded." << std::endl;
 }
 


### PR DESCRIPTION
This would be very valuable when working with: https://github.com/OPM/opm-common/pull/454

If this can be merged it would be very valuable to get a switch all the way out to jenkins, or alternatively the default for `allowExtraKeywords` could be set to `true`.