### PR TITLE
Explicit Tuple Constructors

### DIFF
--- a/examples/test_util/ERft.cpp
+++ b/examples/test_util/ERft.cpp
@@ -300,19 +300,11 @@ std::vector<EclFile::EclEntry> ERft::listOfRftArrays(const std::string& wellName
 
 std::vector<std::string> ERft::listOfWells() const
 {
-    std::vector<std::string> resVect;
-    resVect.resize(wellList.size());
-    std::copy(wellList.begin(), wellList.end(), resVect.begin());
-
-    return std::move(resVect);
+    return { this->wellList.begin(), this->wellList.end() };
 }
 
 
 std::vector<ERft::RftDate> ERft::listOfdates() const
 {
-    std::vector<RftDate> resVect;
-    resVect.resize(dateList.size());
-    std::copy(dateList.begin(), dateList.end(), resVect.begin());
-
-    return std::move(resVect);
+    return { this->dateList.begin(), this->dateList.end() };
 }

--- a/examples/test_util/ERft.cpp
+++ b/examples/test_util/ERft.cpp
@@ -287,7 +287,7 @@ std::vector<EclFile::EclEntry> ERft::listOfRftArrays(const std::string& wellName
         list.emplace_back(array_name[i], array_type[i], array_size[i]);
     }
 
-    return std::move(list);
+    return list;
 }
 
 

--- a/examples/test_util/ERft.cpp
+++ b/examples/test_util/ERft.cpp
@@ -240,7 +240,7 @@ template<> const std::vector<int>&
 ERft::getRft<int>(const std::string& name, const std::string& wellName,
                   int year, int month, int day) const
 {
-    return getRft<int>(name, wellName, {year, month, day});
+    return getRft<int>(name, wellName, RftDate{year, month, day});
 }
 
 
@@ -248,7 +248,7 @@ template<> const std::vector<float>&
 ERft::getRft<float>(const std::string& name, const std::string& wellName,
                     int year, int month, int day) const
 {
-    return getRft<float>(name, wellName, {year, month, day});
+    return getRft<float>(name, wellName, RftDate{year, month, day});
 }
 
 
@@ -256,7 +256,7 @@ template<> const std::vector<double>&
 ERft::getRft<double>(const std::string& name, const std::string& wellName,
                      int year, int month, int day) const
 {
-    return getRft<double>(name, wellName, {year, month, day});
+    return getRft<double>(name, wellName, RftDate{year, month, day});
 }
 
 
@@ -264,7 +264,7 @@ template<> const std::vector<std::string>&
 ERft::getRft<std::string>(const std::string& name, const std::string& wellName,
                           int year, int month, int day) const
 {
-    return getRft<std::string>(name, wellName, {year, month, day});
+    return getRft<std::string>(name, wellName, RftDate{year, month, day});
 }
 
 
@@ -272,7 +272,7 @@ template<> const std::vector<bool>&
 ERft::getRft<bool>(const std::string& name, const std::string& wellName,
                    int year, int month, int day) const
 {
-    return getRft<bool>(name, wellName, {year, month, day});
+    return getRft<bool>(name, wellName, RftDate{year, month, day});
 }
 
 
@@ -284,7 +284,7 @@ std::vector<EclFile::EclEntry> ERft::listOfRftArrays(const std::string& wellName
 
     auto searchInd = arrIndexRange.find(rInd);
     for (int i = searchInd->second.first; i < searchInd->second.second; i++) {
-        list.push_back({array_name[i], array_type[i], array_size[i]});
+        list.emplace_back(array_name[i], array_type[i], array_size[i]);
     }
 
     return std::move(list);
@@ -294,7 +294,7 @@ std::vector<EclFile::EclEntry> ERft::listOfRftArrays(const std::string& wellName
 std::vector<EclFile::EclEntry> ERft::listOfRftArrays(const std::string& wellName,
                                                      int year, int month, int day) const
 {
-    return listOfRftArrays(wellName, {year, month, day});
+    return listOfRftArrays(wellName, RftDate{year, month, day});
 }
 
 

--- a/examples/test_util/ERst.cpp
+++ b/examples/test_util/ERst.cpp
@@ -98,7 +98,10 @@ std::vector<EclFile::EclEntry> ERst::listOfRstArrays(int reportStepNumber)
         OPM_THROW(std::invalid_argument, message);
     }
 
-    for (int i = arrIndexRange[reportStepNumber].first;  i < arrIndexRange[reportStepNumber].second; i++) {
+    const auto& rng = this->arrIndexRange[reportStepNumber];
+    list.reserve(rng.second - rng.first);
+
+    for (int i = rng.first;  i < rng.second; i++) {
         list.emplace_back(array_name[i], array_type[i], array_size[i]);
     }
 

--- a/examples/test_util/ERst.cpp
+++ b/examples/test_util/ERst.cpp
@@ -99,7 +99,7 @@ std::vector<EclFile::EclEntry> ERst::listOfRstArrays(int reportStepNumber)
     }
 
     for (int i = arrIndexRange[reportStepNumber].first;  i < arrIndexRange[reportStepNumber].second; i++) {
-        list.push_back({array_name[i], array_type[i], array_size[i]});
+        list.emplace_back(array_name[i], array_type[i], array_size[i]);
     }
 
     return std::move(list);

--- a/examples/test_util/ERst.cpp
+++ b/examples/test_util/ERst.cpp
@@ -102,7 +102,7 @@ std::vector<EclFile::EclEntry> ERst::listOfRstArrays(int reportStepNumber)
         list.emplace_back(array_name[i], array_type[i], array_size[i]);
     }
 
-    return std::move(list);
+    return list;
 }
 
 

--- a/examples/test_util/ESmry.cpp
+++ b/examples/test_util/ESmry.cpp
@@ -410,7 +410,7 @@ std::string ESmry::makeKeyString(const std::string &keyword, const std::string &
         keyStr = keyword;
     }
 
-    return std::move(keyStr);
+    return keyStr;
 }
 
 

--- a/examples/test_util/EclFile.cpp
+++ b/examples/test_util/EclFile.cpp
@@ -702,6 +702,7 @@ void EclFile::loadData(int arrIndex)
 std::vector<EclFile::EclEntry> EclFile::getList() const
 {
     std::vector<EclEntry> list;
+    list.reserve(this->array_name.size());
 
     for (size_t i = 0; i < array_name.size(); i++) {
         list.emplace_back(array_name[i], array_type[i], array_size[i]);

--- a/examples/test_util/EclFile.cpp
+++ b/examples/test_util/EclFile.cpp
@@ -704,7 +704,7 @@ std::vector<EclFile::EclEntry> EclFile::getList() const
     std::vector<EclEntry> list;
 
     for (size_t i = 0; i < array_name.size(); i++) {
-        list.push_back({array_name[i], array_type[i], array_size[i]});
+        list.emplace_back(array_name[i], array_type[i], array_size[i]);
     }
 
     return std::move(list);

--- a/examples/test_util/EclFile.cpp
+++ b/examples/test_util/EclFile.cpp
@@ -707,7 +707,7 @@ std::vector<EclFile::EclEntry> EclFile::getList() const
         list.emplace_back(array_name[i], array_type[i], array_size[i]);
     }
 
-    return std::move(list);
+    return list;
 }
 
 

--- a/examples/test_util/EclOutput.cpp
+++ b/examples/test_util/EclOutput.cpp
@@ -249,8 +249,7 @@ std::string EclOutput::make_real_string(float value) const
     sprintf (buffer, "%10.7E", value);
 
     if (value == 0.0) {
-        std::string tmpstr("0.00000000E+00");
-        return std::move(tmpstr);
+        return "0.00000000E+00";
     } else {
         std::string tmpstr(buffer);
 
@@ -265,7 +264,7 @@ std::string EclOutput::make_real_string(float value) const
         sprintf (buffer, "%+03i", exp+1);
         tmpstr = tmpstr+buffer;
 
-        return std::move(tmpstr);
+        return tmpstr;
     }
 }
 
@@ -276,9 +275,7 @@ std::string EclOutput::make_doub_string(double value) const
     sprintf (buffer, "%19.13E", value);
 
     if (value == 0.0) {
-        std::string tmpstr("0.00000000000000D+00");
-
-        return std::move(tmpstr);
+        return "0.00000000000000D+00";
     } else {
         std::string tmpstr(buffer);
 
@@ -301,7 +298,7 @@ std::string EclOutput::make_doub_string(double value) const
         sprintf (buffer, "%+03i", exp+1);
         tmpstr = tmpstr + buffer;
 
-        return std::move(tmpstr);
+        return tmpstr;
     }
 }
 

--- a/examples/test_util/EclUtil.cpp
+++ b/examples/test_util/EclUtil.cpp
@@ -20,6 +20,7 @@
 #include <opm/common/ErrorMacros.hpp>
 
 #include <algorithm>
+#include <stdexcept>
 
 
 namespace EIOD = Opm::ecl;

--- a/examples/test_util/EclUtil.cpp
+++ b/examples/test_util/EclUtil.cpp
@@ -56,21 +56,23 @@ double Opm::ecl::flipEndianDouble(double num)
 
 std::tuple<int, int> Opm::ecl::block_size_data_binary(eclArrType arrType)
 {
+    using BlockSizeTuple = std::tuple<int, int>;
+
     switch (arrType) {
     case EIOD::INTE:
-        return {EIOD::sizeOfInte, EIOD::MaxBlockSizeInte};
+        return BlockSizeTuple{EIOD::sizeOfInte, EIOD::MaxBlockSizeInte};
         break;
     case EIOD::REAL:
-        return {EIOD::sizeOfReal, EIOD::MaxBlockSizeReal};
+        return BlockSizeTuple{EIOD::sizeOfReal, EIOD::MaxBlockSizeReal};
         break;
     case EIOD::DOUB:
-        return {EIOD::sizeOfDoub, EIOD::MaxBlockSizeDoub};
+        return BlockSizeTuple{EIOD::sizeOfDoub, EIOD::MaxBlockSizeDoub};
         break;
     case EIOD::LOGI:
-        return {EIOD::sizeOfLogi, EIOD::MaxBlockSizeLogi};
+        return BlockSizeTuple{EIOD::sizeOfLogi, EIOD::MaxBlockSizeLogi};
         break;
     case EIOD::CHAR:
-        return {EIOD::sizeOfChar, EIOD::MaxBlockSizeChar};
+        return BlockSizeTuple{EIOD::sizeOfChar, EIOD::MaxBlockSizeChar};
         break;
     case EIOD::MESS:
         OPM_THROW(std::invalid_argument, "Type 'MESS' have no associated data");
@@ -84,21 +86,23 @@ std::tuple<int, int> Opm::ecl::block_size_data_binary(eclArrType arrType)
 
 std::tuple<int, int, int> Opm::ecl::block_size_data_formatted(EIOD::eclArrType arrType)
 {
+    using BlockSizeTuple = std::tuple<int, int, int>;
+
     switch (arrType) {
     case EIOD::INTE:
-        return {EIOD::MaxNumBlockInte, EIOD::numColumnsInte, EIOD::columnWidthInte};
+        return BlockSizeTuple{EIOD::MaxNumBlockInte, EIOD::numColumnsInte, EIOD::columnWidthInte};
         break;
     case EIOD::REAL:
-        return {EIOD::MaxNumBlockReal,EIOD::numColumnsReal, EIOD::columnWidthReal};
+        return BlockSizeTuple{EIOD::MaxNumBlockReal,EIOD::numColumnsReal, EIOD::columnWidthReal};
         break;
     case EIOD::DOUB:
-        return {EIOD::MaxNumBlockDoub,EIOD::numColumnsDoub, EIOD::columnWidthDoub};
+        return BlockSizeTuple{EIOD::MaxNumBlockDoub,EIOD::numColumnsDoub, EIOD::columnWidthDoub};
         break;
     case EIOD::LOGI:
-        return {EIOD::MaxNumBlockLogi,EIOD::numColumnsLogi, EIOD::columnWidthLogi};
+        return BlockSizeTuple{EIOD::MaxNumBlockLogi,EIOD::numColumnsLogi, EIOD::columnWidthLogi};
         break;
     case EIOD::CHAR:
-        return {EIOD::MaxNumBlockChar,EIOD::numColumnsChar, EIOD::columnWidthChar};
+        return BlockSizeTuple{EIOD::MaxNumBlockChar,EIOD::numColumnsChar, EIOD::columnWidthChar};
         break;
     case EIOD::MESS:
         OPM_THROW(std::invalid_argument, "Type 'MESS' have no associated data") ;

--- a/tests/test_ERft.cpp
+++ b/tests/test_ERft.cpp
@@ -74,62 +74,74 @@ bool operator==(const std::vector<T> & t1, const std::vector<T> & t2)
 
     
 BOOST_AUTO_TEST_CASE(TestERft_1) {
+    using Date = std::tuple<int, int, int>;
 
     std::vector<std::string> ref_wellList= {"A-1H", "B-2H", "INJ", "PROD"};
-    std::vector<std::tuple<int, int, int>> ref_dates= {{2015,1,1},{2015,9,1},{2016,5,31},{2017,7,31}};
+    std::vector<Date> ref_dates= {
+        Date{2015,1, 1},
+        Date{2015,9, 1},
+        Date{2016,5,31},
+        Date{2017,7,31},
+    };
 
-    const std::vector<std::pair<std::string,std::tuple<int, int, int>>> ref_rftList = {{"PROD",{2015,1,1}},{"INJ",{2015,1,1}},{"A-1H",{2015,9,1}}, {"B-2H",{2016,5,31}}, {"PROD",{2017,7,31}}};
+    const std::vector<std::pair<std::string,Date>> ref_rftList = {
+        {"PROD", Date{2015,1, 1}},
+        {"INJ" , Date{2015,1, 1}},
+        {"A-1H", Date{2015,9, 1}},
+        {"B-2H", Date{2016,5,31}},
+        {"PROD", Date{2017,7,31}}
+    };
 
     std::string testFile="SPE1CASE1.RFT";
 
     ERft rft1(testFile);
 
     std::vector<std::string> wellList = rft1.listOfWells();
-    std::vector<std::tuple<int, int, int>> rftDates = rft1.listOfdates();
-    std::vector<std::pair<std::string,std::tuple<int, int, int>>> rftList = rft1.listOfRftReports();
+    std::vector<Date> rftDates = rft1.listOfdates();
+    std::vector<std::pair<std::string,Date>> rftList = rft1.listOfRftReports();
 
     BOOST_CHECK_EQUAL(wellList==ref_wellList, true);
     BOOST_CHECK_EQUAL(rftDates==ref_dates, true);
 
     BOOST_CHECK_EQUAL(rftList==ref_rftList, true);
 
-    BOOST_CHECK_EQUAL(rft1.hasRft("PROD", {2015,1,1}), true);
+    BOOST_CHECK_EQUAL(rft1.hasRft("PROD", Date{2015,1,1}), true);
     BOOST_CHECK_EQUAL(rft1.hasRft("PROD",2015,1,1), true);
 
-    BOOST_CHECK_EQUAL(rft1.hasRft("PROD", {2015,10,1}), false);
-    BOOST_CHECK_EQUAL(rft1.hasRft("XXXX", {2015,1,1}), false);
+    BOOST_CHECK_EQUAL(rft1.hasRft("PROD", Date{2015,10,1}), false);
+    BOOST_CHECK_EQUAL(rft1.hasRft("XXXX", Date{2015,1,1}), false);
     BOOST_CHECK_EQUAL(rft1.hasRft("PROD",2015,10,1), false);
     BOOST_CHECK_EQUAL(rft1.hasRft("XXXX",2015,1,1), false);
-    
-   // test member function hasArray
-    
-    BOOST_CHECK_EQUAL(rft1.hasArray("SGAS","B-2H",{2016,5,31}), true);
-    BOOST_CHECK_EQUAL(rft1.hasArray("XXXX","B-2H",{2016,5,31}), false);
 
-    BOOST_CHECK_THROW(rft1.hasArray("SGAS","C-2H",{2016,5,31}),std::invalid_argument);
-    BOOST_CHECK_THROW(rft1.hasArray("SGAS","B-2H",{2016,5,30}),std::invalid_argument);  
-    BOOST_CHECK_THROW(rft1.hasArray("SGAS","C-2H",{2016,5,30}),std::invalid_argument);  
-    BOOST_CHECK_THROW(rft1.hasArray("XXXX","C-2H",{2016,5,30}),std::invalid_argument);  
+   // test member function hasArray
+
+    BOOST_CHECK_EQUAL(rft1.hasArray("SGAS","B-2H", Date{2016,5,31}), true);
+    BOOST_CHECK_EQUAL(rft1.hasArray("XXXX","B-2H", Date{2016,5,31}), false);
+
+    BOOST_CHECK_THROW(rft1.hasArray("SGAS","C-2H", Date{2016,5,31}),std::invalid_argument);
+    BOOST_CHECK_THROW(rft1.hasArray("SGAS","B-2H", Date{2016,5,30}),std::invalid_argument);
+    BOOST_CHECK_THROW(rft1.hasArray("SGAS","C-2H", Date{2016,5,30}),std::invalid_argument);
+    BOOST_CHECK_THROW(rft1.hasArray("XXXX","C-2H", Date{2016,5,30}),std::invalid_argument);
 
    // test member function getRft
 
-    std::vector<int> vect1=rft1.getRft<int>("CONIPOS","B-2H",{2016,5,31});
-    std::vector<float> vect2=rft1.getRft<float>("PRESSURE","B-2H",{2016,5,31});
-    std::vector<std::string> vect3=rft1.getRft<std::string>("WELLETC","B-2H",{2016,5,31});
+    std::vector<int> vect1=rft1.getRft<int>("CONIPOS","B-2H", Date{2016,5,31});
+    std::vector<float> vect2=rft1.getRft<float>("PRESSURE","B-2H", Date{2016,5,31});
+    std::vector<std::string> vect3=rft1.getRft<std::string>("WELLETC","B-2H", Date{2016,5,31});
 
     BOOST_CHECK_EQUAL(vect1.size(), 3);
     BOOST_CHECK_EQUAL(vect2.size(), 3);
     BOOST_CHECK_EQUAL(vect3.size(), 16);
-   
+
     // called with invalid argument, array not existing, wrong well name or wrong date
-    BOOST_CHECK_THROW(std::vector<int> vect1=rft1.getRft<int>("CONIPOS","C-2H",{2016,5,31}),std::invalid_argument);  
-    BOOST_CHECK_THROW(std::vector<int> vect1=rft1.getRft<int>("CONIPOS","B-2H",{2016,5,30}),std::invalid_argument);  
-    BOOST_CHECK_THROW(std::vector<int> vect1=rft1.getRft<int>("XXXXXXX","B-2H",{2016,5,31}),std::invalid_argument);  
-    
+    BOOST_CHECK_THROW(std::vector<int> vect1=rft1.getRft<int>("CONIPOS","C-2H", Date{2016,5,31}),std::invalid_argument);
+    BOOST_CHECK_THROW(std::vector<int> vect1=rft1.getRft<int>("CONIPOS","B-2H", Date{2016,5,30}),std::invalid_argument);
+    BOOST_CHECK_THROW(std::vector<int> vect1=rft1.getRft<int>("XXXXXXX","B-2H", Date{2016,5,31}),std::invalid_argument);
+
     // called with wrong type
-    BOOST_CHECK_THROW(std::vector<int> vect1=rft1.getRft<int>("SGAS","B-2H",{2016,5,31}),std::runtime_error);
-    BOOST_CHECK_THROW(std::vector<float> vect1=rft1.getRft<float>("CONIPOS","B-2H",{2016,5,31}),std::runtime_error);
-    BOOST_CHECK_THROW(std::vector<std::string> vect1=rft1.getRft<std::string>("CONIPOS","B-2H",{2016,5,31}), std::runtime_error);
+    BOOST_CHECK_THROW(std::vector<int> vect1=rft1.getRft<int>("SGAS","B-2H", Date{2016,5,31}),std::runtime_error);
+    BOOST_CHECK_THROW(std::vector<float> vect1=rft1.getRft<float>("CONIPOS","B-2H", Date{2016,5,31}),std::runtime_error);
+    BOOST_CHECK_THROW(std::vector<std::string> vect1=rft1.getRft<std::string>("CONIPOS","B-2H", Date{2016,5,31}), std::runtime_error);
 }
 
 

--- a/tests/test_ERft.cpp
+++ b/tests/test_ERft.cpp
@@ -23,6 +23,7 @@
 #include <iomanip>
 #include <math.h>
 #include <algorithm>
+#include <stdexcept>
 #include <tuple>
 
 #include <examples/test_util/ERft.hpp>

--- a/tests/test_EclRegressionTest.cpp
+++ b/tests/test_EclRegressionTest.cpp
@@ -577,9 +577,15 @@ BOOST_AUTO_TEST_CASE(results_init_2) {
 }
 
 BOOST_AUTO_TEST_CASE(results_unrst_1) {
+    using Date = std::tuple<int, int, int>;
 
     std::vector<int> seqnum1 = {0,1,4,7};
-    std::vector<std::tuple<int,int,int>> dates1 = {{2000,1,1},{2000,1,10},{2000,2,1},{2000,3,1}};
+    std::vector<Date> dates1 = {
+        Date{2000,1, 1},
+        Date{2000,1,10},
+        Date{2000,2, 1},
+        Date{2000,3, 1}
+    };
     std::vector<bool> logihead1 = {false, false,false,true,false,false,false,false,true,false,false,false,false,false,false};
     std::vector<double> doubhead1 = {0.0,1,0, 365, 0.10000000149012E+00,0.15000000596046E+00,0.30000000000000E+01};
     std::vector<double> time1 = {0, 9, 31,60};
@@ -603,7 +609,13 @@ BOOST_AUTO_TEST_CASE(results_unrst_1) {
 // -------------------------
 
     std::vector<int> seqnum2 = {0,1,4,7};
-    std::vector<std::tuple<int,int,int>> dates2 = {{2000,1,1},{2000,1,10},{2000,2,1},{2000,3,1}};
+    std::vector<Date> dates2 = {
+        Date{2000,1, 1},
+        Date{2000,1,10},
+        Date{2000,2, 1},
+        Date{2000,3, 1}
+    };
+
     std::vector<bool> logihead2 = {false, false,false,true,false,false,false,false,true,false,false,false,false,false,false};
     std::vector<double> doubhead2 = {0.0,1,0, 365, 0.10000000149012E+00,0.15000000596046E+00,0.30000000000000E+01};
     std::vector<double> time2 = {0, 9, 31,60};
@@ -696,9 +708,16 @@ BOOST_AUTO_TEST_CASE(results_unrst_1) {
 }
 
 BOOST_AUTO_TEST_CASE(results_unrst_2) {
+    using Date = std::tuple<int, int, int>;
 
     std::vector<int> seqnum1 = {0,1,4,7};
-    std::vector<std::tuple<int,int,int>> dates1 = {{2000,1,1},{2000,1,10},{2000,2,1},{2000,3,1}};
+    std::vector<Date> dates1 = {
+        Date{2000,1, 1},
+        Date{2000,1,10},
+        Date{2000,2, 1},
+        Date{2000,3, 1}
+    };
+
     std::vector<bool> logihead1 = {false, false,false,true,false,false,false,false,true,false,false,false,false,false,false};
     std::vector<double> doubhead1 = {0.0,1,0, 365, 0.10000000149012E+00,0.15000000596046E+00,0.30000000000000E+01};
     std::vector<double> time1 = {0, 9, 31,60};
@@ -724,7 +743,12 @@ BOOST_AUTO_TEST_CASE(results_unrst_2) {
 // reportStepNumber #4 missing in second case
 
     std::vector<int> seqnum2 = {0,1,7};
-    std::vector<std::tuple<int,int,int>> dates2 = {{2000,1,1},{2000,1,10},{2000,3,1}};
+    std::vector<Date> dates2 = {
+        Date{2000,1, 1},
+        Date{2000,1,10},
+        Date{2000,3, 1}
+    };
+
     std::vector<bool> logihead2 = {false, false,false,true,false,false,false,false,true,false,false,false,false,false,false};
     std::vector<double> doubhead2 = {0.0,1,0, 365, 0.10000000149012E+00,0.15000000596046E+00,0.30000000000000E+01};
     std::vector<double> time2 = {0, 9, 60};
@@ -777,9 +801,15 @@ BOOST_AUTO_TEST_CASE(results_unrst_2) {
 
 
 BOOST_AUTO_TEST_CASE(results_unrst_3) {
+    using Date = std::tuple<int, int, int>;
 
     std::vector<int> seqnum1 = {0,1,4,7};
-    std::vector<std::tuple<int,int,int>> dates1 = {{2000,1,1},{2000,1,10},{2000,2,1},{2000,3,1}};
+    std::vector<Date> dates1 = {
+        Date{2000,1, 1},
+        Date{2000,1,10},
+        Date{2000,2, 1},
+        Date{2000,3, 1},
+    };
     std::vector<bool> logihead1 = {false, false,false,true,false,false,false,false,true,false,false,false,false,false,false};
     std::vector<double> doubhead1 = {0.0,1,0, 365, 0.10000000149012E+00,0.15000000596046E+00,0.30000000000000E+01};
     std::vector<double> time1 = {0, 9, 31,60};
@@ -803,7 +833,12 @@ BOOST_AUTO_TEST_CASE(results_unrst_3) {
 // -------------------------
 
     std::vector<int> seqnum2 = {0,1,4,7};
-    std::vector<std::tuple<int,int,int>> dates2 = {{2000,1,1},{2000,1,10},{2000,2,1},{2000,3,1}};
+    std::vector<Date> dates2 = {
+        Date{2000,1, 1},
+        Date{2000,1,10},
+        Date{2000,2, 1},
+        Date{2000,3, 1},
+    };
     std::vector<bool> logihead2 = {false, false,false,true,false,false,false,false,true,false,false,false,false,false,false};
     std::vector<double> doubhead2 = {0.0,1,0, 365, 0.10000000149012E+00,0.15000000596046E+00,0.30000000000000E+01};
     std::vector<double> time2 = {0, 9, 31,60};
@@ -1067,9 +1102,14 @@ BOOST_AUTO_TEST_CASE(results_unsmry_2) {
 }
 
 BOOST_AUTO_TEST_CASE(results_rft_1) {
+    using Date = std::tuple<int, int, int>;
 
     std::vector<float> time1 = {0.0, 40.0, 50.0};
-    std::vector<std::tuple<int, int, int>> date1 = {{2000,1,1},{2000,2,10},{2000,2,20}};
+    std::vector<Date> date1 = {
+        Date{2000,1, 1},
+        Date{2000,2,10},
+        Date{2000,2,20},
+    };
     std::vector<std::string> wellN1 = {"A-1H", "A-1H", "A-2H"};
 
     std::vector<std::vector<int>> conipos1 = {{1,1},{1,1},{2,2}};
@@ -1092,7 +1132,11 @@ BOOST_AUTO_TEST_CASE(results_rft_1) {
     // ------ second case dentical with first case ---------------
 
     std::vector<float> time2 = {0.0, 40.0, 50.0};
-    std::vector<std::tuple<int, int, int>> date2 = {{2000,1,1},{2000,2,10},{2000,2,20}};
+    std::vector<Date> date2 = {
+        Date{2000,1 ,1},
+        Date{2000,2,10},
+        Date{2000,2,20},
+    };
     std::vector<std::string> wellN2 = {"A-1H", "A-1H", "A-2H"};
 
     std::vector<std::vector<int>> conipos2 = {{1,1},{1,1},{2,2}};
@@ -1115,7 +1159,9 @@ BOOST_AUTO_TEST_CASE(results_rft_1) {
     // -----------------third case, only two rfts, second rft in A-1H removed
 
     std::vector<float> time3 = {0.0, 50.0};
-    std::vector<std::tuple<int, int, int>> date3 = {{2000,1,1},{2000,2,20}};
+    std::vector<Date> date3 = {
+        Date{2000,1,1}, Date{2000,2,20},
+    };
     std::vector<std::string> wellN3 = {"A-1H", "A-2H"};
 
     std::vector<std::vector<int>> conipos3 = {{1,1},{2,2}};
@@ -1204,9 +1250,12 @@ BOOST_AUTO_TEST_CASE(results_rft_1) {
 }
 
 BOOST_AUTO_TEST_CASE(results_rft_2) {
+    using Date = std::tuple<int, int, int>;
 
     std::vector<float> time1 = {0.0, 40.0, 50.0};
-    std::vector<std::tuple<int, int, int>> date1 = {{2000,1,1},{2000,2,10},{2000,2,20}};
+    std::vector<Date> date1 = {
+        Date{2000,1,1}, Date{2000,2,10}, Date{2000,2,20},
+    };
     std::vector<std::string> wellN1 = {"A-1H", "A-1H", "A-2H"};
 
     std::vector<std::vector<int>> conipos1 = {{1,1},{1,1},{2,2}};
@@ -1229,7 +1278,9 @@ BOOST_AUTO_TEST_CASE(results_rft_2) {
     // ------ second case dentical with first case ---------------
 
     std::vector<float> time2 = {0.0, 40.0, 50.0};
-    std::vector<std::tuple<int, int, int>> date2 = {{2000,1,1},{2000,2,10},{2000,2,20}};
+    std::vector<Date> date2 = {
+        Date{2000,1,1}, Date{2000,2,10}, Date{2000,2,20},
+    };
     std::vector<std::string> wellN2 = {"A-1H", "A-1H", "A-2H"};
 
     std::vector<std::vector<int>> conipos2 = {{1,1},{1,1},{2,2}};


### PR DESCRIPTION
This pull request makes the `compareECL` branch compile on older compilers such as GCC 4.9 which don't have a sufficiently complete implementation of `std::tuple`.  In  particular, `tuple`'s "conditionally explicit" constructors are all explicitly marked `explicit` in libstdc++ versions of that vintage.

While here, also replace a few instances of
```C++
return std::move(object);
```
with
```
return object;
```
as the former inhibits return value optimisations.